### PR TITLE
ac-feature- implement Apollo state bridge

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { BrowserRouter } from "react-router-dom";
 import { ErrorBoundary } from "react-error-boundary";
 import { ApolloProvider } from "@apollo/client";
@@ -15,8 +15,19 @@ import { SimpleShellLayout } from "./layouts/SimpleShellLayout";
 import { DevCrashTrigger } from "./components/Development/DevCrashTrigger";
 import { useAppStore } from "./store/useAppStore";
 import { AppError } from "./pages/ErrorPages/AppError";
+import { activeRoleVar } from "./api/cache";
 
 const queryClient = new QueryClient();
+
+function ApolloStateBridge() {
+  const activeRole = useAppStore((s) => s.activeRole);
+
+  useEffect(() => {
+    activeRoleVar(activeRole);
+  }, [activeRole]);
+
+  return null;
+}
 
 const App: React.FC = () => {
   const { forceError, setForceError } = useAppStore();
@@ -42,6 +53,7 @@ const App: React.FC = () => {
               <ToastProvider>
                 <ModalProvider>
                   <BrowserRouter>
+                    <ApolloStateBridge />
                     <AppRouting />
                     <DevOverlay />
                   </BrowserRouter>

--- a/src/api/mockApolloClient.ts
+++ b/src/api/mockApolloClient.ts
@@ -1,8 +1,7 @@
 import { ApolloClient, InMemoryCache, HttpLink } from "@apollo/client";
 import type { InteractionState } from "../types/schema";
-import { WORKFLOW } from "../types/schema";
 import { activeRoleVar } from "./cache";
-import { ROLE_PERMISSIONS } from "../types/schema";
+import { getPermittedActions } from "./mocks/common/resolvers";
 
 // This tells Apollo: "Send all GQL queries to this local path"
 const httpLink = new HttpLink({
@@ -16,6 +15,11 @@ export const client = new ApolloClient({
     typePolicies: {
       Query: {
         fields: {
+          _roleDependency: {
+            read() {
+              return activeRoleVar();
+            },
+          },
           search: {
             keyArgs: ["workspaceId", "queryString"],
             merge(existing, incoming, { args }) {
@@ -95,16 +99,15 @@ export const client = new ApolloClient({
             read(_, { readField }) {
               // 1. Get the current status from the cache
               const status = readField('status') as InteractionState;
-              
+              readField('_roleDependency');
+
               // 2. Get the current role from our Reactive Var
               const currentRole = activeRoleVar(); 
 
-              // 3. Re-calculate exactly like we do in the MockLink
-              const workflowActions = WORKFLOW[status]?.allowedActions || [];
-              return workflowActions.filter(action => 
-                ROLE_PERMISSIONS[currentRole].includes(action)
-              );
-            }
+              // 3. Re-calculate
+              return getPermittedActions(status, currentRole);
+            },
+            merge: false,
           },
         },
       },

--- a/src/api/mocks/common/resolvers.ts
+++ b/src/api/mocks/common/resolvers.ts
@@ -38,8 +38,14 @@ export function getPermittedActions(
   );
 }
 
-export function getProfileInteractionsAndActivities(workspaceId: string, identityId: string) {
-  const mockDb = getMockDb();
+export function getProfileInteractionsAndActivities(
+  workspaceId: string, 
+  identityId: string,
+  options?: {
+    db?: ReturnType<typeof getMockDb>;
+  }
+) {
+  const mockDb = options?.db ?? getMockDb();
   let activities = mockDb.interactionActivities.filter((activity) => {
     return activity.workspaceId === workspaceId;
   })
@@ -86,8 +92,15 @@ export function getProfileInteractionsAndActivities(workspaceId: string, identit
   return { activities, interactions}
 }
 
-function resolveIdentityStats(workspaceId: string, identityId: string): IdentityStats {
-  const { activities, interactions } = getProfileInteractionsAndActivities(workspaceId, identityId);
+function resolveIdentityStats(
+  workspaceId: string, 
+  identityId: string,
+  options?: {
+    db?: ReturnType<typeof getMockDb>;
+  }
+): IdentityStats {
+  const mockDb = options?.db ?? getMockDb();
+  const { activities, interactions } = getProfileInteractionsAndActivities(workspaceId, identityId, { db: mockDb });
 
   const lastActivityAt = activities.length
     ? Math.max(...activities.map(a => new Date(a.occurredAt).getTime()))
@@ -114,14 +127,19 @@ function resolveIdentityStats(workspaceId: string, identityId: string): Identity
   }
 }
 
-export function resolveIdentity(identity: IdentityRecord): Identity & { stats: IdentityStats} {
-  const mockDb = getMockDb();
+export function resolveIdentity(
+  identity: IdentityRecord, 
+  options?: {
+    role?: Role;
+    db?: ReturnType<typeof getMockDb>;
+  }): Identity & { stats: IdentityStats} {
+  const mockDb = options?.db ?? getMockDb();
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { companyId, ...resolvedIdentity } =  {
     ...identity,
     __typename: "Identity" as const,
     company: mockDb.identities.find((id: IdentityRecord) => id.id === identity.companyId),
-    stats: resolveIdentityStats(identity.workspaceId, identity.id),
+    stats: resolveIdentityStats(identity.workspaceId, identity.id, { db: mockDb }),
   };
 
   return resolvedIdentity;

--- a/src/api/mocks/common/resolvers.ts
+++ b/src/api/mocks/common/resolvers.ts
@@ -3,7 +3,10 @@ import type {
   Interaction,
   InteractionActivity,
   InteractionParty, 
+  InteractionState,
+  InteractionAction,
 } from "../../../types/schema";
+import type { Role } from "../../cache";
 import type {
   InteractionActivityRecord,
   InteractionActivityMetadataRecord_Decision
@@ -22,6 +25,17 @@ type IdentityStats = {
   active: number;
   awaiting: number;
   lastActivityAt: number | null;
+}
+
+export function getPermittedActions(
+  status: InteractionState,
+  role: Role
+): InteractionAction[] {
+  const workflowActions = WORKFLOW[status]?.allowedActions || [];
+
+  return workflowActions.filter(action =>
+    ROLE_PERMISSIONS[role].includes(action)
+  );
 }
 
 export function getProfileInteractionsAndActivities(workspaceId: string, identityId: string) {
@@ -113,14 +127,21 @@ export function resolveIdentity(identity: IdentityRecord): Identity & { stats: I
   return resolvedIdentity;
 }
 
-export function resolveInteraction(interaction: InteractionRecord): Interaction {
-  const currentRole = useAppStore.getState().activeRole;
+export function resolveInteraction(
+    interaction: InteractionRecord, 
+    options?: {
+      role?: Role;
+      db?: ReturnType<typeof getMockDb>;
+    }
+  ): Interaction {
+  const currentRole = options?.role ?? useAppStore.getState().activeRole;
+  const mockDb = options?.db ?? getMockDb();
   // Use that role to filter the buttons/actions
-  const workflowActions = WORKFLOW[interaction.status].allowedActions;
-  const permittedActions = workflowActions.filter(action => 
-    ROLE_PERMISSIONS[currentRole].includes(action)
+  const permittedActions = getPermittedActions(
+    interaction.status,
+    currentRole
   );
-  const mockDb = getMockDb();
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { creatorId, currentReviewerId, ...resolvedInteraction } =  {
     __typename: "Interaction" as const,

--- a/src/api/services/identitiesService.ts
+++ b/src/api/services/identitiesService.ts
@@ -62,7 +62,7 @@ export const identityService = {
   processProfile: async (workspaceId: string, identityId: string) => {
     const db = getMockDb();
     const { activities, interactions } = getProfileInteractionsAndActivities(workspaceId as string, identityId as string);
-    const resolvedInteractions = interactions.map(resolveInteraction);
+    const resolvedInteractions = interactions.map((interaction) => resolveInteraction(interaction));
     const resolvedActivities = activities.map((ia) => resolveInteractionActivity(ia));
 
     const identityRecord = db.identities.find(i => i.id === identityId && i.workspaceId === workspaceId);

--- a/src/api/services/interactionService.ts
+++ b/src/api/services/interactionService.ts
@@ -91,8 +91,6 @@ export const interactionService = {
     });
     }
 
-    // const { permittedActions, data, description, ...prunedResolvedInteraction} = resolvedInteraction;
-
     const resolvedActivities = newActivities
     .map(activity => resolveInteractionActivity(activity))
     .filter((activity): activity is InteractionActivity => activity !== null)

--- a/src/api/services/interactionsListService.ts
+++ b/src/api/services/interactionsListService.ts
@@ -18,7 +18,7 @@ export const interactionsListService = {
     const { workspaceId, sortBy, filters = {}, offset = 0, limit = 50 } = variables ?? {};
 
     // 1. Base Workspace Filter
-    let resolved = allInteractions.map(resolveInteraction).filter((i: Interaction) => i.workspaceId === workspaceId);
+    let resolved = allInteractions.map((interaction) => resolveInteraction(interaction)).filter((i: Interaction) => i.workspaceId === workspaceId);
     
     // 2. Apply Filters (Ported from your Apollo logic)
     const statusFilter = filters.status;
@@ -88,7 +88,7 @@ export const interactionsListService = {
     if (workspaceId) {
         workspaceInteractions = allInteractions.filter((interaction) => interaction.workspaceId === workspaceId);
     }
-    const resolved = workspaceInteractions.map(resolveInteraction);
+    const resolved = workspaceInteractions.map((interaction) => resolveInteraction(interaction));
 
     const parties = Array.from(
         new Map(

--- a/src/api/services/searchService.ts
+++ b/src/api/services/searchService.ts
@@ -16,7 +16,8 @@ export const searchService = {
     const { workspaceId, queryString, offset = 0, limit = 10 } = variables;
     const normalizedQuery = queryString?.toLowerCase().trim() ?? "";
 
-    const mockedDBTranslation = allInteractions.map(resolveInteraction);
+    const mockedDBTranslation = allInteractions.map((interaction) => resolveInteraction(interaction));
+    
     const matchingIdentities =
         normalizedQuery.length === 0
             ? []

--- a/src/routes/WorkspaceRouteBoundary.tsx
+++ b/src/routes/WorkspaceRouteBoundary.tsx
@@ -10,39 +10,28 @@ import { DEFAULT_WORKSPACE_ID } from "./AppRoutes";
 
 export function WorkspaceRouteBoundary() {
   const { workspaceId } = useParams<{ workspaceId: string }>();
-  const hasHydrated = useAppStore((state) => state._hasHydrated);
-  // A. Get the persisted workspace from Zustand first (Synchronous!)
-  const persistedWorkspace = useAppStore((state) => state.activeWorkspace);
-  const setPersistedWorkspace = useAppStore(
-    (state) => state.setActiveWorkspace,
-  );
 
-  // B. Run the query (Always call this at the top level)
+  const persistedWorkspace = useAppStore((s) => s.activeWorkspace);
+  const setPersistedWorkspace = useAppStore((s) => s.setActiveWorkspace);
+
   const { workspaces, loading } = useWorkspacesList();
 
-  // C. Find the workspace in the fresh data if it exists
+  // 1. Derive workspace from fresh data first
   const freshWorkspace =
-    workspaces?.find((w: Workspace) => w.id === workspaceId) || workspaces?.[0];
+    workspaces?.find((w: Workspace) => w.id === workspaceId) ?? workspaces?.[0];
 
-  // D. Update the store when fresh data arrives (Optional but good)
+  // 2. Sync to Zustand when fresh data arrives
   useEffect(() => {
     if (freshWorkspace) {
       setPersistedWorkspace(freshWorkspace);
     }
   }, [freshWorkspace, setPersistedWorkspace]);
 
-  // IMPORTANT: If Zustand hasn't finished reading localStorage,
-  // do not show a loading screen or navigate yet.
-  // 1. Wait for Zustand hydration
-  if (!hasHydrated) return null;
+  // 3. Compute active workspace (fresh > persisted)
+  const activeWorkspace = freshWorkspace ?? persistedWorkspace;
 
-  // 2. Logic Check: Do we have a match in the cache/store?
-  const activeWorkspace = freshWorkspace || persistedWorkspace;
-  const isMatch = activeWorkspace?.id === workspaceId;
-
-  // 3. The "No-Flash" Spinner Logic
-  // Only show the spinner if we are loading AND we don't have a matching workspace to show yet.
-  if (loading && !isMatch) {
+  // 4. Loading state (only when we truly have nothing)
+  if (loading && !activeWorkspace) {
     return (
       <SimpleShellLayout>
         <LoadingScreen />
@@ -50,17 +39,17 @@ export function WorkspaceRouteBoundary() {
     );
   }
 
-  // 4. Handle Redirects (URL doesn't match the data we found)
-  if (!loading && activeWorkspace && activeWorkspace.id !== workspaceId) {
+  // 5. Redirect if URL doesn't match resolved workspace
+  if (activeWorkspace && activeWorkspace.id !== workspaceId) {
     return <Navigate to={`/w/${activeWorkspace.id}/dashboard`} replace />;
   }
 
-  // 5. Final Guard
-  if (!activeWorkspace) {
+  // 6. Final fallback (extremely rare)
+  if (!activeWorkspace && !loading) {
     return <Navigate to={`/w/${DEFAULT_WORKSPACE_ID}/dashboard`} replace />;
   }
 
-  // 6. Render
+  // 7. Render
   return (
     <WorkspaceProvider workspace={activeWorkspace}>
       <Outlet />

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -1,8 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import { activeRoleVar } from '../api/cache';
 import type { Workspace } from '../types/schema';
-import { client } from '../api/mockApolloClient';
 
 type Role = 'Admin' | 'Editor' | 'Viewer';
 export type DataStrategy = 'APOLLO' | 'TANSTACK';
@@ -35,9 +33,7 @@ export const useAppStore = create<AppState>()(
       setActiveWorkspace: (workspace: Workspace) => set({ activeWorkspace: workspace }),
       isSyncing: false,
       setRole: (role) => {
-        // 1. Update the Apollo world (triggers the TypePolicy read)
-        activeRoleVar(role); 
-        // 2. Update the Zustand world (triggers your React hooks)
+        // Update the Zustand world (triggers your React hooks)
         set({ activeRole: role });
       },
       setSyncing: (bool) => set({ isSyncing: bool }),
@@ -62,17 +58,6 @@ export const useAppStore = create<AppState>()(
         return () => {
           // This runs when hydration finishes
           state.setHasHydrated(true);
-
-          // 🔥 Re-sync Apollo reactive var
-          if (state.activeRole) {
-            activeRoleVar(state.activeRole);
-            // TODO:
-            // Apollo reactive var dependency is not triggering TypePolicy recompute on hydration.
-            // Attempted Query.currentRole bridge caused instability in list/detail views.
-            // Revisit with safer dependency tracking or cache invalidation strategy
-            // in order to see the actions change when switching to Apollo 
-            client.reFetchObservableQueries();
-          }
         };
       },
       partialize: (state) => ({ 

--- a/tests/unit/interactions/resolveIdentity.test.ts
+++ b/tests/unit/interactions/resolveIdentity.test.ts
@@ -1,0 +1,91 @@
+import { resolveIdentity } from "../../../src/api/mocks/common/resolvers";
+import { getMockDb } from "../../../src/mocks/mockDB";
+import type { InteractionActivityMetadataRecord_Reviewer } from "../../../src/types/api";
+
+describe('resolveIdentity', () => {
+  const db = getMockDb();
+
+  const mockDb = {
+    ...db,
+    identities: db.identities.map((identity, index) => {
+      if (index === 0) return { ...identity, id: 'company-1' };
+      if (index === 1) return { ...identity, id: 'person-1', workspaceId: 'alpha', companyId: 'company-1' };
+      return identity;
+    }),
+    interactions: db.interactions.map((interaction, index) => {
+      if (index === 0) return { 
+        ...interaction, 
+        id: 'int-1',
+        status: 'APPROVED',
+        parties: [
+          { role: 'SELLER', identityId: 'person-1' },
+          { role: 'BUYER', identityId: 'person-2' },
+        ], 
+      };
+      if (index === 1) return { ...interaction, status: 'IN_REVIEW', currentReviewerId: 'person-1' };
+      return interaction;
+    }),
+    interactionActivities: db.interactionActivities.map((activity, index) => {
+      if (index === 0) return { 
+        ...activity, 
+        workspaceId: 'alpha',
+        interactionId: 'int-1', 
+        metadata: {
+          __typename: 'InteractionActivityMetadataRecord_Reviewer' as const,
+          nextReviewer: {
+            ...(activity.metadata as InteractionActivityMetadataRecord_Reviewer).nextReviewer,
+            identityId: 'person-1',
+          },
+        },
+      };
+      if (index === 1) return { 
+        ...activity, 
+        workspaceId: 'alpha',
+        interactionId: 'int-1',
+        actorId: 'person-1', 
+      };
+      return activity;
+    }),
+  };
+
+  const baseIdentity = {
+    ...mockDb.identities[1],
+    id: 'person-1',
+  };
+
+  const resolve = (identityOverride = {}) =>
+    resolveIdentity(
+      { ...baseIdentity, ...identityOverride },
+      { role: 'Admin', db: mockDb }
+    );
+
+  it('hydrates company correctly', () => {
+    const result = resolve();
+    expect(result.company?.id).toBe('company-1');
+  });
+
+  it('computes users total interactions correctly', () => {
+    const result = resolve();
+    expect(result.stats.total).toEqual(2);
+  });
+
+  it('computes users interactions awaiting action correctly', () => {
+    const result = resolve();
+    expect(result.stats.awaiting).toEqual(1);
+  });
+
+  it('computes users active interactions correctly', () => {
+    const result = resolve();
+    expect(result.stats.active).toEqual(1);
+  });
+
+  it('handles null company gracefully', () => {
+    const identity = {
+      ...baseIdentity,
+      companyId: null,
+    };
+
+    const result = resolve(identity);
+    expect(result.company).toBeUndefined();
+  });
+});

--- a/tests/unit/interactions/resolveInteraction.test.ts
+++ b/tests/unit/interactions/resolveInteraction.test.ts
@@ -1,0 +1,80 @@
+import { getPermittedActions } from "../../../src/api/mocks/common/resolvers";
+import { resolveInteraction } from "../../../src/api/mocks/common/resolvers";
+import { getMockDb } from "../../../src/mocks/mockDB";
+
+describe('resolveInteraction', () => {
+  const db = getMockDb();
+
+  const mockDb = {
+    ...db,
+    identities: db.identities.map((identity, index) => {
+      if (index === 0) return { ...identity, id: 'user-1' };
+      if (index === 1) return { ...identity, id: 'user-2' };
+      return identity;
+    }),
+  };
+
+  const baseInteraction = {
+    ...mockDb.interactions[0],
+    id: 'int-1',
+    status: 'DRAFT',
+    creatorId: 'user-1',
+    currentReviewerId: 'user-2',
+    parties: [
+      { role: 'SELLER', identityId: 'user-1' },
+      { role: 'BUYER', identityId: 'user-2' },
+    ],
+  };
+
+  const resolve = (interactionOverride = {}) =>
+    resolveInteraction(
+      { ...baseInteraction, ...interactionOverride },
+      { role: 'Admin', db: mockDb }
+    );
+
+  it('hydrates creator and reviewer correctly', () => {
+    const result = resolve();
+
+    expect(result.creator.id).toBe('user-1');
+    expect(result.currentReviewer?.id).toBe('user-2');
+  });
+
+  it('computes permittedActions correctly', () => {
+    const result = resolve();
+
+    const expected = getPermittedActions('DRAFT', 'Admin');
+
+    expect(result.permittedActions).toEqual(expected);
+  });
+
+  it('maps parties with identities', () => {
+    const result = resolve();
+
+    expect(result.parties).toHaveLength(2);
+    expect(result.parties[0].identity.id).toBe('user-1');
+  });
+
+  it('filters out missing identities in parties', () => {
+    const interactionWithBadParty = {
+      ...baseInteraction,
+      parties: [
+        { role: 'SELLER', identityId: 'missing-id' },
+      ],
+    };
+
+    const result = resolve(interactionWithBadParty);
+
+    expect(result.parties).toHaveLength(0);
+  });
+
+  it('handles null currentReviewer gracefully', () => {
+    const interaction = {
+      ...baseInteraction,
+      currentReviewerId: null,
+    };
+
+    const result = resolve(interaction);
+
+    expect(result.currentReviewer).toBeNull();
+  });
+});

--- a/tests/unit/permissions/getPermittedActions.test.ts
+++ b/tests/unit/permissions/getPermittedActions.test.ts
@@ -1,0 +1,21 @@
+import { getPermittedActions } from "../../../src/api/mocks/common/resolvers";
+
+describe('getPermittedActions', () => {
+  it('returns correct actions for ADMIN in DRAFT state', () => {
+    const result = getPermittedActions('DRAFT', 'Admin');
+
+    expect(result).toEqual(['SUBMIT']); 
+  });
+
+  it('filters actions correctly for Viewer role', () => {
+    const result = getPermittedActions('DRAFT', 'Viewer');
+
+    expect(result).toEqual([]); 
+  });
+
+  it('returns empty array for unknown status', () => {
+    const result = getPermittedActions('UNKNOWN', 'Admin');
+
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
**📝 Summary**
This PR implements a bridge between the Zustand store and Apollo due to the `activeRole` variable becoming out-of-sync between the two.  The main goals are:

- Survive hydration
- Survive protocol switching
- Do NOT require query refetching
- Do NOT destabilize cache reads
- Preserve architectural separation

Implementing this bridge fixes an issue where switching the `dataStrategy` in the DevHUD from TanStack to Apollo resulted in "stale" `permittedActions` in the UI on the first render due to the calculation of permittedActions being done with a stale activeRole var within the Apollo cache - as the "reactive" var was out of sync with the variable stored in Zustand.

**🛠️ Key Changes**
- Added ApolloStateBridge in App.tsx - using useEffect to sync the activeRoleVar at the top level of the app before any recalculation of permittedActions would be needed.
- Removed logic in Zustand store which tried to update the activeRoleVar for Apollo to keep them in sync

NOW: Zustand owns state, React syncs it, and Apollo derives from it

**Resulting flow:**
When `status` changes (already in place):

- Apollo updates normalized entity
- TypePolicy re-runs
- permittedActions recalculates

When `role` changes:

- activeRoleVar() updates
- Apollo reactivity triggers
- TypePolicy re-runs
- permittedActions recalculates

This PR also implements unit tests for various resolver functions in order to test pure logic and service behavior.
 