### PR TITLE
ac-hotfix - Ensure active queries refetch on tab focus

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,7 +44,7 @@ const App: React.FC = () => {
   useEffect(() => {
     const handleFocus = async () => {
       await ensureMsw();
-      await queryClient.invalidateQueries();
+      await queryClient.refetchQueries({ type: "active" });
     };
 
     window.addEventListener("focus", handleFocus);


### PR DESCRIPTION
Fixes an issue where queries could remain stale after the app regains focus (observed in Vercel deployments).

Replaces `invalidateQueries` with `refetchQueries({ type: "active" })` in the focus handler to ensure visible data is reliably refreshed after idle.

This is a targeted fix to validate behavior in production before further refinement.