### PR TITLE
ac-hotfix Ensure refetch fires on Try Again button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,7 +55,7 @@ const App: React.FC = () => {
     <ErrorBoundary
       onReset={() => {
         setForceError(null);
-        queryClient.invalidateQueries(); // make sure to refetch query after some failure
+        queryClient.refetchQueries({ type: "active" }); // make sure to refetch query after some failure
       }}
       resetKeys={[forceError]}
       fallbackRender={({ resetErrorBoundary }) => (

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -71,7 +71,7 @@ export const AppLayout: React.FC = () => {
             <ErrorBoundary
               onReset={() => {
                 setForceError(null);
-                queryClient.invalidateQueries(); // make sure to refetch query after some failure
+                queryClient.refetchQueries({ type: "active" }); // make sure to refetch query after some failure
               }}
               resetKeys={[forceError]}
               fallbackRender={({ resetErrorBoundary }) => (


### PR DESCRIPTION
I swapped out `queryClient.invalidateQueries` for `queryClient.refetchQueries({ type: "active" })` on the Try Again button on error pages to ensure refetch occurs.

Since this is a user-triggered update caused by some error, I wanted to use explicit refetching to guarantee execution, rather than continuing to use the invalidateQueries more appropriate for passive updates.